### PR TITLE
gh #71 Enhance TV Settings HAL: Address Missing Elements & Expand on PR #70

### DIFF
--- a/config/pq_capabilities.json
+++ b/config/pq_capabilities.json
@@ -11,7 +11,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -35,7 +35,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -59,7 +59,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -89,7 +89,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -144,7 +144,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -168,7 +168,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -192,7 +192,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -230,7 +230,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -277,7 +277,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -301,7 +301,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -325,7 +325,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -364,7 +364,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -411,7 +411,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -435,7 +435,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -459,7 +459,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -497,7 +497,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -544,7 +544,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -568,7 +568,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -592,7 +592,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -630,7 +630,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "IP"
                 ],
                 "HLG": [
@@ -676,7 +676,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -700,7 +700,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -724,7 +724,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -762,7 +762,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -813,7 +813,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -837,7 +837,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -861,7 +861,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -899,7 +899,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -949,7 +949,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -971,7 +971,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -993,7 +993,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -1029,7 +1029,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -1074,7 +1074,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -1098,7 +1098,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -1122,7 +1122,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -1160,7 +1160,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -1215,7 +1215,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -1242,7 +1242,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -1269,7 +1269,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -1296,7 +1296,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -1323,7 +1323,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -1350,7 +1350,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -1377,7 +1377,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -1431,7 +1431,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -1503,7 +1503,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ]
             },
             "Vivid": {
@@ -1514,7 +1514,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ]
             },
             "Sports": {
@@ -1525,7 +1525,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ]
             },
             "Theater": {
@@ -1533,7 +1533,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ]
@@ -1554,7 +1554,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite"
+                    "Composite1"
                 ],
                 "DV": [
                     "IP",
@@ -1588,7 +1588,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite"
+                    "Composite1"
                 ],
                 "DV": [
                     "IP",
@@ -1621,7 +1621,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite"
+                    "Composite1"
                 ],
                 "DV": [
                     "IP",
@@ -1654,7 +1654,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite"
+                    "Composite1"
                 ],
                 "DV": [
                     "IP",
@@ -1687,7 +1687,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite"
+                    "Composite1"
                 ],
                 "DV": [
                     "IP",
@@ -1727,7 +1727,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite"
+                    "Composite1"
                 ],
                 "DV": [
                     "IP",
@@ -1743,7 +1743,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite"
+                    "Composite1"
                 ],
                 "DV": [
                     "IP",
@@ -1860,7 +1860,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -1887,7 +1887,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -1914,7 +1914,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -1941,7 +1941,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -1968,7 +1968,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -1995,7 +1995,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -2049,7 +2049,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -2110,7 +2110,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -2134,7 +2134,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -2158,7 +2158,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -2188,7 +2188,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -2240,7 +2240,7 @@
                 "HDMI4",
                 "IP",
                 "Tuner",
-                "Composite1"
+                "Composite11"
             ]
         }
     },
@@ -2303,7 +2303,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -2327,7 +2327,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -2351,7 +2351,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -2381,7 +2381,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite",
+                    "Composite1",
                     "Tuner",
                     "IP"
                 ],
@@ -2441,7 +2441,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -2468,7 +2468,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -2495,7 +2495,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -2522,7 +2522,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -2549,7 +2549,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -2576,7 +2576,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -2603,7 +2603,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",
@@ -2657,7 +2657,7 @@
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite1"
                 ],
                 "HLG": [
                     "IP",

--- a/config/pq_capabilities.json
+++ b/config/pq_capabilities.json
@@ -6,12 +6,11 @@
         },
         "platformSupport": true,
         "context": {
-            "Standard": {
+            "Sports": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -20,7 +19,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -28,88 +26,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -119,7 +35,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -128,7 +43,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -136,68 +50,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -207,7 +59,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -216,7 +67,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -224,26 +74,43 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
-                ]
-            },
-            "Dark": {
+                ],
                 "DV": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             },
-            "Bright": {
+            "Game": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
                 "DV": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             },
@@ -252,7 +119,14 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
                     "IP"
                 ]
             }
@@ -265,12 +139,11 @@
         },
         "platformSupport": true,
         "context": {
-            "Standard": {
+            "Sports": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -279,7 +152,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -287,88 +159,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -378,7 +168,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -387,7 +176,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -395,7 +183,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -405,7 +192,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -414,7 +200,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -422,7 +207,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -430,79 +214,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "AI PQ": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             },
@@ -511,7 +222,44 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
                     "IP"
                 ]
             }
@@ -524,12 +272,11 @@
         },
         "platformSupport": true,
         "context": {
-            "Standard": {
+            "Sports": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -538,7 +285,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -546,88 +292,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -637,7 +301,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -646,7 +309,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -654,7 +316,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -664,7 +325,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -673,7 +333,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -681,7 +340,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -689,34 +347,15 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             },
-            "Sports": {
-                "SDR": [
+            "IQ": {
+                "DV": [
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
                     "IP"
                 ]
             },
@@ -725,7 +364,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -734,7 +372,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -742,8 +379,13 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
                     "IP"
                 ]
             },
@@ -752,25 +394,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "IQ": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             }
@@ -783,12 +406,11 @@
         },
         "platformSupport": true,
         "context": {
-            "Standard": {
+            "Sports": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -797,7 +419,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -805,88 +426,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -896,7 +435,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -905,7 +443,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -913,7 +450,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -923,7 +459,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -932,7 +467,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -940,7 +474,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -948,79 +481,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "AI PQ": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             },
@@ -1029,7 +489,44 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
                     "IP"
                 ]
             }
@@ -1042,12 +539,11 @@
         },
         "platformSupport": true,
         "context": {
-            "Standard": {
+            "Sports": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -1056,7 +552,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -1064,88 +559,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -1155,7 +568,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -1164,7 +576,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -1172,7 +583,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -1182,7 +592,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -1191,7 +600,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -1199,7 +607,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -1207,79 +614,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "AI PQ": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             },
@@ -1288,7 +622,43 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Composite",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
                     "IP"
                 ]
             }
@@ -1301,12 +671,11 @@
         },
         "platformSupport": true,
         "context": {
-            "Standard": {
+            "Sports": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -1315,7 +684,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -1323,88 +691,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -1414,7 +700,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -1423,7 +708,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -1431,7 +715,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -1441,7 +724,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -1450,7 +732,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -1458,7 +739,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -1466,79 +746,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "AI PQ": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             },
@@ -1547,7 +754,44 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
                     "IP"
                 ]
             }
@@ -1564,12 +808,11 @@
         },
         "platformSupport": true,
         "context": {
-            "Standard": {
+            "Sports": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -1578,7 +821,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -1586,88 +828,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -1677,7 +837,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -1686,7 +845,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -1694,7 +852,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -1704,7 +861,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -1713,7 +869,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -1721,7 +876,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -1729,79 +883,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "AI PQ": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             },
@@ -1810,207 +891,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            }
-        }
-    },
-    "DimmingMode": {
-        "rangeInfo": {
-            "options": [
-                "Fixed",
-                "Global"
-            ]
-        },
-        "platformSupport": true,
-        "context": {
-            "Standard": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Theater": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
                     "IP"
                 ]
             },
@@ -2019,7 +899,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -2028,7 +907,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -2036,8 +914,149 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ]
+            }
+        }
+    },
+    "DimmingMode": {
+        "rangeInfo": {
+            "options": [
+                "Local",
+                "Fixed",
+                "Global"
+            ]
+        },
+        "platformSupport": true,
+        "context": {
+            "Sports": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ]
+            },
+            "Theater": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ]
+            },
+            "Game": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
                     "IP"
                 ]
             }
@@ -2050,12 +1069,11 @@
         },
         "platformSupport": true,
         "context": {
-            "Game": {
+            "Sports": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -2064,7 +1082,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -2072,7 +1089,54 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Theater": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Game": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
                     "Tuner",
                     "IP"
                 ],
@@ -2080,7 +1144,51 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
                     "IP"
                 ]
             }
@@ -2101,252 +1209,252 @@
         "context": {
             "Standard": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ],
                 "HLG": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
+                    "HDMI4"
                 ],
                 "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
+                    "IP",
                     "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Theater": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI4"
                 ]
             },
             "Sports": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ],
                 "HLG": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
+                    "HDMI4"
                 ],
                 "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Theater": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
                     "Tuner",
-                    "IP"
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "FilmMaker": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
                 ]
             },
             "AI PQ": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ],
                 "HLG": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
+                    "HDMI4"
                 ],
                 "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
+                    "IP",
                     "Tuner",
-                    "IP"
-                ]
-            },
-            "Dark": {
-                "DV": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI4"
                 ]
             },
             "IQ": {
                 "DV": [
+                    "IP",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "IP",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "IP",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Game": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "IP"
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "DV": [
+                    "IP",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
                 ]
             }
         }
@@ -2360,20 +1468,18 @@
         "context": {
             "Bright": {
                 "DV": [
+                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI3"
                 ]
             },
             "IQ": {
                 "DV": [
+                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI3"
                 ]
             }
         }
@@ -2391,46 +1497,35 @@
         "context": {
             "Standard": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ]
             },
             "Vivid": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ]
             },
-            "EnergySaving": {
+            "Sports": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ]
             },
             "Theater": {
@@ -2438,40 +1533,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "AI PQ": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -2488,252 +1549,27 @@
         "context": {
             "Standard": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Theater": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ],
                 "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
+                    "IP",
                     "Tuner",
-                    "IP"
-                ],
-                "HLG": [
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "AI PQ": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI3"
                 ]
             },
             "IQ": {
                 "DV": [
+                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI3"
                 ]
             }
         }
@@ -2747,252 +1583,26 @@
         "context": {
             "Standard": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Theater": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ],
                 "DV": [
+                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "AI PQ": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI3"
                 ]
             },
             "IQ": {
                 "DV": [
+                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI3"
                 ]
             }
         }
@@ -3006,252 +1616,26 @@
         "context": {
             "Standard": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Theater": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ],
                 "DV": [
+                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "AI PQ": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI3"
                 ]
             },
             "IQ": {
                 "DV": [
+                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI3"
                 ]
             }
         }
@@ -3265,252 +1649,26 @@
         "context": {
             "Standard": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Theater": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ],
                 "DV": [
+                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "AI PQ": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI3"
                 ]
             },
             "IQ": {
                 "DV": [
+                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI3"
                 ]
             }
         }
@@ -3524,218 +1682,26 @@
         "context": {
             "Standard": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Theater": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "AI PQ": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Dark": {
                 "DV": [
+                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI3"
                 ]
             },
             "IQ": {
                 "DV": [
+                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI3"
                 ]
             }
         }
@@ -3756,252 +1722,34 @@
         "context": {
             "Standard": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ],
-                "HLG": [
+                "DV": [
+                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
+                    "HDMI3"
                 ]
             },
             "EnergySaving": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Theater": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ],
                 "DV": [
+                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "AI PQ": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "IQ": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI3"
                 ]
             }
         }
@@ -4058,7 +1806,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             },
@@ -4067,9 +1814,7 @@
                     "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI3"
                 ]
             },
             "Dark": {
@@ -4077,7 +1822,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             },
@@ -4086,7 +1830,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             }
@@ -4097,267 +1840,239 @@
         "rangeInfo": {
             "options": [
                 "Standard",
-                "Vivid",
-                "EnergySaving",
-                "Custom",
+                "Sports",
                 "Theater",
                 "Game",
-                "Sports",
-                "AI PQ",
                 "Dark",
                 "Bright",
-                "IQ"
+                "IQ",
+                "EnergySaving",
+                "Vivid",
+                "AI PQ"
             ]
         },
         "context": {
             "Standard": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ],
                 "HLG": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
+                    "HDMI4"
                 ],
                 "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
+                    "IP",
                     "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Theater": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI4"
                 ]
             },
             "Sports": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ],
                 "HLG": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
+                    "HDMI4"
                 ],
                 "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Theater": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
                     "Tuner",
-                    "IP"
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
                 ]
             },
             "AI PQ": {
                 "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
+                    "Composite"
                 ],
                 "HLG": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
+                    "HDMI4"
                 ],
                 "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
+                    "IP",
                     "Tuner",
-                    "IP"
-                ]
-            },
-            "Dark": {
-                "DV": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
+                    "HDMI4"
                 ]
             },
             "IQ": {
                 "DV": [
+                    "IP",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "IP",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "IP",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Game": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "IP"
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "DV": [
+                    "IP",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
                 ]
             }
         }
@@ -4390,12 +2105,11 @@
             ],
         "platformSupport": true,
         "context": {
-            "Standard": {
+            "Sports": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -4404,7 +2118,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -4412,88 +2125,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -4503,7 +2134,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -4512,7 +2142,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -4520,68 +2149,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -4591,7 +2158,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -4600,7 +2166,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -4608,26 +2173,43 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
-                ]
-            },
-            "Dark": {
+                ],
                 "DV": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             },
-            "Bright": {
+            "Game": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
                 "DV": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             },
@@ -4636,7 +2218,14 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
                     "IP"
                 ]
             }
@@ -4651,7 +2240,7 @@
                 "HDMI4",
                 "IP",
                 "Tuner",
-                "Composite"
+                "Composite1"
             ]
         }
     },
@@ -4659,22 +2248,18 @@
         "rangeInfo": {
             "options": [
                 "24",
-                "25",
                 "30",
                 "50",
-                "60",
-                "23.98",
-                "29.97",
-                "59.94"
+                "60"
             ]
         }
     },
     "VideoFormat": {
         "rangeInfo": {
             "options": [
-                "SDR",
                 "HDR10",
                 "HLG",
+                "SDR",
                 "DV"
             ]
         }
@@ -4682,23 +2267,13 @@
     "VideoResolution": {
         "rangeInfo": {
             "options": [
-                "720x240p"
-                "720x288p"
-                "720x480i"
-                "720x480p"
-                "960x540p"
-                "720x576i"
-                "720x576p"
-                "800x600p"
-                "1280x720p"
-                "1280x1024p"
-                "1280x768p"
-                "1280x960p"
-                "1920x1080i"
-                "2560x1080p"
-                "1920x1200p"
-                "2560x1440p"
-                "4096x2160p"
+                "720x240",
+                "2880x240",
+                "720x288",
+                "2880x288",
+                "1920x1080",
+                "3840x2160",
+                "4096x2160"
             ]
         }
     },
@@ -4723,12 +2298,11 @@
             ],
         "platformSupport": true,
         "context": {
-            "Standard": {
+            "Sports": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -4737,7 +2311,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -4745,88 +2318,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Custom": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -4836,7 +2327,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -4845,7 +2335,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -4853,68 +2342,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "IP"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -4924,7 +2351,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -4933,7 +2359,6 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -4941,26 +2366,43 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "Tuner",
                     "IP"
-                ]
-            },
-            "Dark": {
+                ],
                 "DV": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             },
-            "Bright": {
+            "Game": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "Tuner",
+                    "IP"
+                ],
                 "DV": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
                     "IP"
                 ]
             },
@@ -4969,7 +2411,14 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
                     "IP"
                 ]
             }
@@ -4984,13 +2433,254 @@
         },
         "platformSupport": true,
         "context": {
-            "IQ": {
-                "DV": [
+            "Standard": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "IP"
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Sports": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Theater": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "FilmMaker": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "IP",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "IP",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "IP",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ]
+            },
+            "Game": {
+                "SDR": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite"
+                ],
+                "HLG": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "HDR10": [
+                    "IP",
+                    "Tuner",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
+                ],
+                "DV": [
+                    "IP",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4"
                 ]
             }
         }

--- a/config/pq_capabilities.json
+++ b/config/pq_capabilities.json
@@ -6,11 +6,12 @@
         },
         "platformSupport": true,
         "context": {
-            "Sports": {
+            "Standard": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -19,6 +20,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -26,6 +28,88 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -35,6 +119,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -43,6 +128,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -50,6 +136,68 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Game": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Sports": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -59,6 +207,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -67,6 +216,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -74,51 +224,8 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "IP"
-                ]
-            },
-            "IQ": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
                     "IP"
                 ]
             },
@@ -127,6 +234,25 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             }
@@ -139,11 +265,12 @@
         },
         "platformSupport": true,
         "context": {
-            "Sports": {
+            "Standard": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -152,6 +279,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -159,6 +287,88 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -168,6 +378,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -176,6 +387,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -183,6 +395,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -192,6 +405,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -200,6 +414,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -207,6 +422,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -214,14 +430,34 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             },
-            "IQ": {
-                "DV": [
+            "Sports": {
+                "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ]
             },
@@ -230,6 +466,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -238,6 +475,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -245,13 +483,8 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
                     "IP"
                 ]
             },
@@ -260,6 +493,25 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             }
@@ -272,11 +524,12 @@
         },
         "platformSupport": true,
         "context": {
-            "Sports": {
+            "Standard": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -285,6 +538,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -292,6 +546,88 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -301,6 +637,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -309,6 +646,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -316,6 +654,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -325,6 +664,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -333,6 +673,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -340,6 +681,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -347,15 +689,34 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             },
-            "IQ": {
-                "DV": [
+            "Sports": {
+                "SDR": [
                     "HDMI1",
                     "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ]
             },
@@ -364,6 +725,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -372,6 +734,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -379,13 +742,8 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
                     "IP"
                 ]
             },
@@ -394,6 +752,25 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             }
@@ -406,11 +783,12 @@
         },
         "platformSupport": true,
         "context": {
-            "Sports": {
+            "Standard": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -419,6 +797,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -426,6 +805,88 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -435,6 +896,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -443,6 +905,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -450,6 +913,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -459,6 +923,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -467,6 +932,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -474,6 +940,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -481,14 +948,34 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             },
-            "IQ": {
-                "DV": [
+            "Sports": {
+                "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ]
             },
@@ -497,6 +984,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -505,6 +993,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -512,13 +1001,8 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
                     "IP"
                 ]
             },
@@ -527,6 +1011,25 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             }
@@ -539,11 +1042,12 @@
         },
         "platformSupport": true,
         "context": {
-            "Sports": {
+            "Standard": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -552,6 +1056,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -559,6 +1064,88 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -568,6 +1155,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -576,6 +1164,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -583,6 +1172,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -592,6 +1182,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -600,6 +1191,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -607,6 +1199,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -614,14 +1207,34 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             },
-            "IQ": {
-                "DV": [
+            "Sports": {
+                "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ]
             },
@@ -630,13 +1243,16 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
+                    "Tuner",
                     "IP"
                 ],
                 "HLG": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -644,13 +1260,8 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
                     "IP"
                 ]
             },
@@ -659,6 +1270,25 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             }
@@ -671,11 +1301,12 @@
         },
         "platformSupport": true,
         "context": {
-            "Sports": {
+            "Standard": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -684,6 +1315,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -691,6 +1323,88 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -700,6 +1414,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -708,6 +1423,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -715,6 +1431,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -724,6 +1441,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -732,6 +1450,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -739,6 +1458,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -746,14 +1466,34 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             },
-            "IQ": {
-                "DV": [
+            "Sports": {
+                "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ]
             },
@@ -762,6 +1502,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -770,6 +1511,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -777,13 +1519,8 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
                     "IP"
                 ]
             },
@@ -792,6 +1529,25 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             }
@@ -808,11 +1564,12 @@
         },
         "platformSupport": true,
         "context": {
-            "Sports": {
+            "Standard": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -821,6 +1578,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -828,6 +1586,88 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -837,6 +1677,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -845,6 +1686,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -852,6 +1694,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -861,6 +1704,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -869,6 +1713,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -876,6 +1721,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -883,14 +1729,34 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             },
-            "IQ": {
-                "DV": [
+            "Sports": {
+                "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ]
             },
@@ -899,6 +1765,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -907,6 +1774,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -914,13 +1782,8 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
                     "IP"
                 ]
             },
@@ -929,6 +1792,25 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             }
@@ -937,18 +1819,18 @@
     "DimmingMode": {
         "rangeInfo": {
             "options": [
-                "Local",
                 "Fixed",
                 "Global"
             ]
         },
         "platformSupport": true,
         "context": {
-            "Sports": {
+            "Standard": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -957,12 +1839,97 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ],
                 "HDR10": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ]
             },
@@ -971,6 +1938,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -979,12 +1947,16 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ],
                 "HDR10": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ]
             },
@@ -993,6 +1965,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -1001,26 +1974,43 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ],
                 "HDR10": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ]
             },
-            "IQ": {
-                "DV": [
+            "Sports": {
+                "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ]
             },
@@ -1029,6 +2019,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -1037,26 +2028,16 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ],
                 "HDR10": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "IP"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
                     "IP"
                 ]
             }
@@ -1069,59 +2050,12 @@
         },
         "platformSupport": true,
         "context": {
-            "Sports": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Theater": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Tuner",
-                    "IP"
-                ]
-            },
             "Game": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -1130,6 +2064,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -1137,6 +2072,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -1144,51 +2080,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "IP"
-                ]
-            },
-            "IQ": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "IP"
-                ]
-            },
-            "AI PQ": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Tuner",
-                    "IP"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             }
@@ -1209,252 +2101,252 @@
         "context": {
             "Standard": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
                 "HLG": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ],
-                "HDR10": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
-                ],
-                "HLG": [
-                    "IP",
                     "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
+                    "IP"
                 ],
                 "HDR10": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "Theater": {
-                "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
-                ],
-                "HLG": [
-                    "IP",
                     "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ],
-                "HDR10": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
+                    "IP"
                 ]
             },
             "Vivid": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
                 "HLG": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ],
                 "HDR10": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ]
             },
             "EnergySaving": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
                 "HLG": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ],
                 "HDR10": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ]
             },
-            "FilmMaker": {
+            "Custom": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
                 "HLG": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ],
                 "HDR10": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ]
             },
-            "AI PQ": {
+            "Theater": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
                 "HLG": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ],
                 "HDR10": [
-                    "IP",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "IQ": {
-                "DV": [
-                    "IP",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "IP",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "IP",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
+                    "IP"
                 ]
             },
             "Game": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
                 "HLG": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ],
                 "HDR10": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ],
                 "DV": [
-                    "IP",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Sports": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             }
         }
@@ -1468,18 +2360,20 @@
         "context": {
             "Bright": {
                 "DV": [
-                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             },
             "IQ": {
                 "DV": [
-                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             }
         }
@@ -1497,35 +2391,46 @@
         "context": {
             "Standard": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ]
             },
             "Vivid": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ]
             },
-            "Sports": {
+            "EnergySaving": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ]
             },
             "Theater": {
@@ -1533,6 +2438,40 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Game": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Sports": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -1549,27 +2488,252 @@
         "context": {
             "Standard": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite"
-                ],
-                "DV": [
-                    "IP",
+                    "HDMI4",
+                    "Composite",
                     "Tuner",
+                    "IP"
+                ],
+                "HLG": [
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Theater": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Game": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Sports": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             },
             "IQ": {
                 "DV": [
-                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             }
         }
@@ -1583,26 +2747,252 @@
         "context": {
             "Standard": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite"
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
-                "DV": [
-                    "IP",
+                "HLG": [
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Theater": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Game": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Sports": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             },
             "IQ": {
                 "DV": [
-                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             }
         }
@@ -1616,26 +3006,252 @@
         "context": {
             "Standard": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite"
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
-                "DV": [
-                    "IP",
+                "HLG": [
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Theater": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Game": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Sports": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             },
             "IQ": {
                 "DV": [
-                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             }
         }
@@ -1649,26 +3265,252 @@
         "context": {
             "Standard": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite"
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
-                "DV": [
-                    "IP",
+                "HLG": [
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Theater": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Game": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Sports": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             },
             "IQ": {
                 "DV": [
-                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             }
         }
@@ -1682,26 +3524,218 @@
         "context": {
             "Standard": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite"
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
-                "DV": [
-                    "IP",
+                "HLG": [
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Theater": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Sports": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             },
             "IQ": {
                 "DV": [
-                    "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             }
         }
@@ -1722,34 +3756,252 @@
         "context": {
             "Standard": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite"
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
-                "DV": [
-                    "IP",
+                "HLG": [
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ]
             },
             "EnergySaving": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "Composite"
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
-                "DV": [
-                    "IP",
+                "HLG": [
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Theater": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Game": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Sports": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             }
         }
@@ -1806,6 +4058,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             },
@@ -1814,7 +4067,9 @@
                     "IP",
                     "HDMI1",
                     "HDMI2",
-                    "HDMI3"
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             },
             "Dark": {
@@ -1822,6 +4077,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             },
@@ -1830,6 +4086,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             }
@@ -1840,239 +4097,267 @@
         "rangeInfo": {
             "options": [
                 "Standard",
-                "Sports",
+                "Vivid",
+                "EnergySaving",
+                "Custom",
                 "Theater",
                 "Game",
+                "Sports",
+                "AI PQ",
                 "Dark",
                 "Bright",
-                "IQ",
-                "EnergySaving",
-                "Vivid",
-                "AI PQ"
+                "IQ"
             ]
         },
         "context": {
             "Standard": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
                 "HLG": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ],
-                "HDR10": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
-                ],
-                "HLG": [
-                    "IP",
                     "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
+                    "IP"
                 ],
                 "HDR10": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "Theater": {
-                "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
-                ],
-                "HLG": [
-                    "IP",
                     "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ],
-                "HDR10": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
+                    "IP"
                 ]
             },
             "Vivid": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
                 "HLG": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ],
                 "HDR10": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ]
             },
             "EnergySaving": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
                 "HLG": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ],
                 "HDR10": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ]
             },
-            "AI PQ": {
+            "Custom": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
                 "HLG": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ],
                 "HDR10": [
-                    "IP",
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
+                    "IP"
                 ]
             },
-            "IQ": {
-                "DV": [
-                    "IP",
+            "Theater": {
+                "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "IP",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "IP",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ]
             },
             "Game": {
                 "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
+                    "Composite",
+                    "Tuner",
+                    "IP"
                 ],
                 "HLG": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ],
                 "HDR10": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
                 ],
                 "DV": [
-                    "IP",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
-                    "HDMI4"
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Sports": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "AI PQ": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Dark": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
                 ]
             }
         }
@@ -2105,11 +4390,12 @@
             ],
         "platformSupport": true,
         "context": {
-            "Sports": {
+            "Standard": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -2118,6 +4404,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -2125,6 +4412,88 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -2134,6 +4503,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -2142,6 +4512,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -2149,6 +4520,68 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Game": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Sports": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -2158,6 +4591,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -2166,6 +4600,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -2173,51 +4608,8 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "IP"
-                ]
-            },
-            "IQ": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
                     "IP"
                 ]
             },
@@ -2226,6 +4618,25 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             }
@@ -2240,7 +4651,7 @@
                 "HDMI4",
                 "IP",
                 "Tuner",
-                "Composite1"
+                "Composite"
             ]
         }
     },
@@ -2248,18 +4659,22 @@
         "rangeInfo": {
             "options": [
                 "24",
+                "25",
                 "30",
                 "50",
-                "60"
+                "60",
+                "23.98",
+                "29.97",
+                "59.94"
             ]
         }
     },
     "VideoFormat": {
         "rangeInfo": {
             "options": [
+                "SDR",
                 "HDR10",
                 "HLG",
-                "SDR",
                 "DV"
             ]
         }
@@ -2267,13 +4682,23 @@
     "VideoResolution": {
         "rangeInfo": {
             "options": [
-                "720x240",
-                "2880x240",
-                "720x288",
-                "2880x288",
-                "1920x1080",
-                "3840x2160",
-                "4096x2160"
+                "720x240p"
+                "720x288p"
+                "720x480i"
+                "720x480p"
+                "960x540p"
+                "720x576i"
+                "720x576p"
+                "800x600p"
+                "1280x720p"
+                "1280x1024p"
+                "1280x768p"
+                "1280x960p"
+                "1920x1080i"
+                "2560x1080p"
+                "1920x1200p"
+                "2560x1440p"
+                "4096x2160p"
             ]
         }
     },
@@ -2298,11 +4723,12 @@
             ],
         "platformSupport": true,
         "context": {
-            "Sports": {
+            "Standard": {
                 "SDR": [
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -2311,6 +4737,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -2318,6 +4745,88 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Vivid": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "EnergySaving": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Custom": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -2327,6 +4836,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -2335,6 +4845,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -2342,6 +4853,68 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ]
+            },
+            "Game": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Sports": {
+                "SDR": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Composite",
+                    "Tuner",
+                    "IP"
+                ],
+                "HLG": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "Tuner",
+                    "IP"
+                ],
+                "HDR10": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ]
@@ -2351,6 +4924,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Composite",
                     "Tuner",
                     "IP"
@@ -2359,6 +4933,7 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
                     "IP"
                 ],
@@ -2366,51 +4941,8 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
                     "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "IP"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Composite",
-                    "Tuner",
-                    "IP"
-                ],
-                "HLG": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Tuner",
-                    "IP"
-                ],
-                "HDR10": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "Tuner",
-                    "IP"
-                ],
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "IP"
-                ]
-            },
-            "IQ": {
-                "DV": [
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
                     "IP"
                 ]
             },
@@ -2419,6 +4951,25 @@
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "Bright": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
+                    "IP"
+                ]
+            },
+            "IQ": {
+                "DV": [
+                    "HDMI1",
+                    "HDMI2",
+                    "HDMI3",
+                    "HDMI4",
                     "IP"
                 ]
             }
@@ -2433,254 +4984,13 @@
         },
         "platformSupport": true,
         "context": {
-            "Standard": {
-                "SDR": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite"
-                ],
-                "HLG": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ],
-                "HDR10": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "Sports": {
-                "SDR": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite"
-                ],
-                "HLG": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ],
-                "HDR10": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "Theater": {
-                "SDR": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite"
-                ],
-                "HLG": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ],
-                "HDR10": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "Vivid": {
-                "SDR": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite"
-                ],
-                "HLG": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ],
-                "HDR10": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "EnergySaving": {
-                "SDR": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite"
-                ],
-                "HLG": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ],
-                "HDR10": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "FilmMaker": {
-                "SDR": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite"
-                ],
-                "HLG": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ],
-                "HDR10": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "AI PQ": {
-                "SDR": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4",
-                    "Composite"
-                ],
-                "HLG": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ],
-                "HDR10": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
             "IQ": {
                 "DV": [
-                    "IP",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "Bright": {
-                "DV": [
-                    "IP",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "Dark": {
-                "DV": [
-                    "IP",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ]
-            },
-            "Game": {
-                "SDR": [
-                    "IP",
-                    "Tuner",
                     "HDMI1",
                     "HDMI2",
                     "HDMI3",
                     "HDMI4",
-                    "Composite"
-                ],
-                "HLG": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ],
-                "HDR10": [
-                    "IP",
-                    "Tuner",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
-                ],
-                "DV": [
-                    "IP",
-                    "HDMI1",
-                    "HDMI2",
-                    "HDMI3",
-                    "HDMI4"
+                    "IP"
                 ]
             }
         }

--- a/include/tvSettings.h
+++ b/include/tvSettings.h
@@ -4225,7 +4225,7 @@ tvError_t GetBacklightModeCaps(tvBacklightMode_t** backlight_mode, size_t* num_b
  * @brief Saves the BacklightMode value
  *
  * This function saves the BacklightMode value in picture profile database for the specific picture mode, primary video format type
- * and primary video source. The saved BacklightMode value should be applied automatically by whenever the
+ * and primary video source. The saved BacklightMode value should be applied automatically whenever the
  * specified picture mode is selected, specified primary video format is played and specified primary video source is selected.
  * There will be no change in current BacklightMode value applied in PQ module.
  *

--- a/include/tvSettings.h
+++ b/include/tvSettings.h
@@ -1836,9 +1836,8 @@ tvError_t SaveSourcePictureMode(tvVideoSrcType_t videoSrcType, tvVideoFormatType
  *
  * This function gets the PictureMode capabilities from the PictureMode section of the pq_capabilities.json.
  *
- * If this feature is global (`num_contexts == 0`) and platform_support is true,
- * the corresponding pqmode, source, and format entries should be retrieved from the picturemode section
- * of pq_capabilities.json
+ * For this feature num_context must be greater than zero. The context structure must be populated with 
+ * the supported PictureMode, VideoSource, and VideoFormat specific to the platform.
  *
  * The `context_caps` parameter receives a pointer to a `tvContextCaps_t` structure that lists the different
  * configuration contexts that this feature can be configured for.

--- a/include/tvSettings.h
+++ b/include/tvSettings.h
@@ -4222,6 +4222,31 @@ tvError_t GetVideoResolutionCaps( tvVideoResolution_t ** resolution, size_t* num
  */
 tvError_t GetBacklightModeCaps(tvBacklightMode_t** backlight_mode, size_t* num_backlight_mode, tvContextCaps_t** context_caps);
 
+/**
+ * @brief Saves the BacklightMode value
+ *
+ * This function saves the BacklightMode value in picture profile database for the specific picture mode, primary video format type
+ * and primary video source. The saved BacklightMode value should be applied automatically by whenever the
+ * specified picture mode is selected, specified primary video format is played and specified primary video source is selected.
+ * There will be no change in current BacklightMode value applied in PQ module.
+ *
+ * @param[in] videoSrcType          - Source input value. Valid value will be a member of ::tvVideoSrcType_t
+ * @param[in] pq_mode               - Picture mode index. Valid value will be a member of ::tvPQModeIndex_t
+ * @param[in] videoFormatType       - Video format type value. Valid value will be a member of ::tvVideoFormatType_t
+ * @param[in] value                 - Value of the BacklightMode to be set. Valid value will be member of ::tvBacklightMode_t
+ *
+ * @return tvError_t
+ *
+ * @retval tvERROR_NONE             - Success
+ * @retval tvERROR_INVALID_PARAM    - Input parameter is invalid
+ * @retval tvERROR_INVALID_STATE    - Interface is not initialized
+ * @retval tvERROR_OPERATION_NOT_SUPPORTED - Operation is not supported
+ * @retval tvERROR_GENERAL          - Underlying failures - SoC, memory, etc
+ *
+ * @pre TvInit() should be called before calling this API
+ */
+tvError_t SaveBacklightMode(tvVideoSrcType_t videoSrcType, int pq_mode, tvVideoFormatType_t videoFormatType, tvBacklightMode_t value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/tvTypes.h
+++ b/include/tvTypes.h
@@ -398,6 +398,7 @@ typedef enum tvPQParameterIndex {
     PQ_PARAM_MEMC,                             //!< Picture parameter is MEMC
     PQ_PARAM_MULTI_POINT_WB,                   //!< Picture parameter is Multi-Point WB
     PQ_PARAM_DOLBY_VISION_CALIBRATION,         //!< Picture parameter is Dolby Vision Calibration
+    PQ_PARAM_BACKLIGHT_MODE,                   //!< Picture parameter is BacklightMode
     PQ_PARAM_MAX                               //!< End of enum
 }tvPQParameterIndex_t;
 


### PR DESCRIPTION
This PR covers the improvements introduced in PR #70, further refining the tvSettings HAL by addressing missing elements and expanding its functionality. These updates enhance the system's configurability and improve consistency across various components.

https://github.com/rdkcentral/rdkv-halif-tvsettings/pull/70

Required changes:
1. Replace all Composite with Composite1 in **config/pq_capabilities.json**
2. Add SaveBacklightMode() API and description
3. Add PQ_PARAM_BACKLIGHT_MODE enum
4. Modify GetTVPictureModeCaps description appropriately