### PR TITLE
gh #75 Added a new API to enable or disable PQ processing

### DIFF
--- a/include/tvSettings.h
+++ b/include/tvSettings.h
@@ -4249,12 +4249,13 @@ tvError_t SaveBacklightMode(tvVideoSrcType_t videoSrcType, int pq_mode, tvVideoF
 /**
  * @brief Enables or disables PQ processing
  *
- * When PQ processing is disabled, HAL should bypass PQ pipeline by setting PQ parameters to disabled state or
- * setting PQ parameters to neutral values.
+ * When PQ processing is disabled, HAL should bypass the PQ pipeline by setting PQ parameters to either a disabled state or neutral values.
+ * If the API receives a request to disable PQ when it is already disabled, or to enable it when it is already enabled, the operation
+ * will still be processed and return tvERROR_NONE, confirming success without an actual state change.
  *
- * @param[in] value - Boolean flag to indicate the enable or disable of PQ processing. 
- *              	- 'true' : disable PQ processing
- *              	- 'false': enable PQ processing
+ * @param[in] isEnabled - Boolean flag to control PQ processing. 
+ *              	       - 'true' : Enables PQ processing
+ *              	       - 'false': Disables PQ processing
  *
  * @return tvError_t
  *
@@ -4265,7 +4266,7 @@ tvError_t SaveBacklightMode(tvVideoSrcType_t videoSrcType, int pq_mode, tvVideoF
  * 
  * @pre tvInit() must be called before calling this API
  */
-tvError_t DisablePQ(bool value);
+tvError_t SetPQProcessingEnabled(bool isEnabled);
 
 #ifdef __cplusplus
 }

--- a/include/tvSettings.h
+++ b/include/tvSettings.h
@@ -4247,18 +4247,26 @@ tvError_t GetBacklightModeCaps(tvBacklightMode_t** backlight_mode, size_t* num_b
 tvError_t SaveBacklightMode(tvVideoSrcType_t videoSrcType, int pq_mode, tvVideoFormatType_t videoFormatType, tvBacklightMode_t value);
 
 /**
- * @brief This API is used to enable or disable PQ processing.
+ * @brief Enables or disables PQ processing
  *
- * When PQ processing is disabled, HAL should bypass pq pipeline by setting pq parameters to disabled state or
- * setting pq parameters to neutral values.
+ * When PQ processing is disabled, HAL should bypass PQ pipeline by setting PQ parameters to disabled state or
+ * setting PQ parameters to neutral values.
  *
  * @param[in] value - Boolean flag to indicate the enable or disable of PQ processing. 
  *              	- 'true' : disable PQ processing
  *              	- 'false': enable PQ processing
+ *
+ * @return tvError_t
+ *
+ * @retval tvERROR_NONE             - Success
+ * @retval tvERROR_INVALID_PARAM    - Input parameter is invalid
+ * @retval tvERROR_INVALID_STATE    - Interface is not initialized
+ * @retval tvERROR_OPERATION_NOT_SUPPORTED - Operation is not supported
+ * @retval tvERROR_GENERAL          - Underlying failures - SoC, memory, etc
  * 
  * @pre tvInit() must be called before calling this API
  */
-void DisablePQ(bool value);
+tvError_t DisablePQ(bool value);
 
 #ifdef __cplusplus
 }

--- a/include/tvSettings.h
+++ b/include/tvSettings.h
@@ -4247,20 +4247,17 @@ tvError_t GetBacklightModeCaps(tvBacklightMode_t** backlight_mode, size_t* num_b
 tvError_t SaveBacklightMode(tvVideoSrcType_t videoSrcType, int pq_mode, tvVideoFormatType_t videoFormatType, tvBacklightMode_t value);
 
 /**
-* @brief This API is used to enable or disable PQ processing.
-*
-
-* When PQ processing is disabled, HAL should bypass pq pipeline by setting pq parameters to disabled state or
-
-* setting pq parameters to neutral values.
-
-*
-* @param [in] bool - value indicates the enable or disable of PQ processing. 
-*              true - disable PQ processing
-*              false - enable PQ processing
-* 
-* @pre tvInit() must be called before calling this API
-*/
+ * @brief This API is used to enable or disable PQ processing.
+ *
+ * When PQ processing is disabled, HAL should bypass pq pipeline by setting pq parameters to disabled state or
+ * setting pq parameters to neutral values.
+ *
+ * @param[in] value - Boolean flag to indicate the enable or disable of PQ processing. 
+ *              	- 'true' : disable PQ processing
+ *              	- 'false': enable PQ processing
+ * 
+ * @pre tvInit() must be called before calling this API
+ */
 void DisablePQ(bool value);
 
 #ifdef __cplusplus

--- a/include/tvSettings.h
+++ b/include/tvSettings.h
@@ -4259,7 +4259,6 @@ tvError_t SaveBacklightMode(tvVideoSrcType_t videoSrcType, int pq_mode, tvVideoF
  * @return tvError_t
  *
  * @retval tvERROR_NONE             - Success
- * @retval tvERROR_INVALID_PARAM    - Input parameter is invalid
  * @retval tvERROR_INVALID_STATE    - Interface is not initialized
  * @retval tvERROR_OPERATION_NOT_SUPPORTED - Operation is not supported
  * @retval tvERROR_GENERAL          - Underlying failures - SoC, memory, etc

--- a/include/tvSettings.h
+++ b/include/tvSettings.h
@@ -4246,6 +4246,23 @@ tvError_t GetBacklightModeCaps(tvBacklightMode_t** backlight_mode, size_t* num_b
  */
 tvError_t SaveBacklightMode(tvVideoSrcType_t videoSrcType, int pq_mode, tvVideoFormatType_t videoFormatType, tvBacklightMode_t value);
 
+/**
+* @brief This API is used to enable or disable PQ processing.
+*
+
+* When PQ processing is disabled, HAL should bypass pq pipeline by setting pq parameters to disabled state or
+
+* setting pq parameters to neutral values.
+
+*
+* @param [in] bool - value indicates the enable or disable of PQ processing. 
+*              true - disable PQ processing
+*              false - enable PQ processing
+* 
+* @pre tvInit() must be called before calling this API
+*/
+void DisablePQ(bool value);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Currently, there is no API available to control PQ processing, limiting flexibility in system behavior. To address this, a new API should be introduced that allows enabling or disabling PQ processing as needed.
When PQ processing is disabled, HAL should bypass the PQ pipeline by either setting PQ parameters to a disabled state or adjusting them to neutral values, ensuring no unintended processing occurs.