### PR TITLE
gh #91 Add caps entry for Factory WhiteBalance in pq_capabilities.json

### DIFF
--- a/config/pq_capabilities.json
+++ b/config/pq_capabilities.json
@@ -2862,7 +2862,7 @@
             "Gain",
             "Offset"
         ],
-	"colorTemperature": [
+	"ColorTemperature": [
             "Standard",
             "Warm",
             "Cold",

--- a/config/pq_capabilities.json
+++ b/config/pq_capabilities.json
@@ -2836,5 +2836,37 @@
                 ]
             }
         }
+    },
+    "FactoryWhiteBalance": {
+        "rangeGain": {
+            "from": 0,
+            "to": 2047
+        },
+        "rangeOffset": {
+            "from": -1024,
+            "to": 1023
+        },
+        "control": [
+            "Gain",
+            "Offset"
+        ],
+	"colorTemperature": [
+            "Standard",
+            "Warm",
+            "Cold",
+            "UserDefined"
+        ],
+        "color": [
+            "Red",
+            "Green",
+            "Blue"
+        ],
+        "platformSupport": true,
+        "source" : [
+            "ALL",
+            "HDMI",
+            "TV",
+            "AV"
+        ]
     }
 }


### PR DESCRIPTION
Currently FactoryWhiteBalance entry was missing in pq_capabilities.json.
FactoryWhiteBalance params required to validate all factory related TVS-HAL APIs.