### PR TITLE
Modify DynamicContrast APIs Description to Provide More Clarity

### DIFF
--- a/include/tvSettings.h
+++ b/include/tvSettings.h
@@ -1552,7 +1552,12 @@ tvError_t GetLowLatencyStateCaps(int* max_latency, tvContextCaps_t ** context_ca
  * The value is discarded and default value from picture profile database is used when primary video format
  * or primary video source or picture mode changes.
  *
- * @param[in] dynamicContrastEnable  - Dynamic contrast enable flag value (valid values are "enabled" for enable and "disabled" for disable)
+ * Note: This API is independent of EnableDynamicContrast(). The dynamic contrast module is enabled by default,
+ * and this API can be used directly to control runtime behavior.
+ *
+ * @param[in] dynamicContrastMode - Dynamic contrast flag value:
+ *                                    - "enabled": Enable dynamic contrast
+ *                                    - "disabled": Disable dynamic contrast
  *
  * @return tvError_t
  *
@@ -1567,7 +1572,7 @@ tvError_t GetLowLatencyStateCaps(int* max_latency, tvContextCaps_t ** context_ca
  * @see GetDynamicContrast()
  */
 
-tvError_t SetDynamicContrast(const char *dynamicContrastEnable);
+tvError_t SetDynamicContrast(const char *dynamicContrastMode);
 
 /**
  * @brief Gets the current Dynamic contrast mode
@@ -1575,7 +1580,12 @@ tvError_t SetDynamicContrast(const char *dynamicContrastEnable);
  * This function gets the current dynamic contrast value for the primary video source selected,
  * primary video format played and picture mode selected.
  *
- * @param[out] isDynamicContrastEnabled        - Current dynamic contrast mode flag value. (valid values are "enabled" for enable and "disabled" for disable)
+ * Note: This API is independent of EnableDynamicContrast(). The dynamic contrast module is enabled by default,
+ * and this API can be used directly to control runtime behavior.
+ *
+ * @param[out] dynamicContrastMode - Dynamic contrast flag value:
+ *                                    - "enabled": Enable dynamic contrast
+ *                                    - "disabled": Disable dynamic contrast
  *
  * @return tvError_t
  *
@@ -1589,7 +1599,7 @@ tvError_t SetDynamicContrast(const char *dynamicContrastEnable);
  *
  * @see SetDynamicContrast()
  */
-tvError_t GetDynamicContrast(char *isDynamicContrastEnabled);
+tvError_t GetDynamicContrast(char *dynamicContrastMode);
 
 /**
  * @brief Sets and saves the dynamic gamma
@@ -2965,11 +2975,14 @@ tvError_t EnableWhiteBalance(bool mode);
 /**
  * @brief Enables or disables the dynamic contrast module
  *
- * This function enables or disabless the dynamic contrast module.
+ * This function enables or disables the dynamic contrast module at the system level.
+ * It is intended for factory-side configuration and is not required for regular PQ pipeline operations.
+ * By default, the dynamic contrast module is enabled in the PQ pipeline, so SetDynamicContrast() and GetDynamicContrast()
+ * can be used directly without invoking this API.
  *
- * @param[in] mode                 - Valid values are true and false. @n
- *                                     true when dynamic contrast module needs to be enabled @n
- *                                      false when dynamic contrast needs to be disabled.
+ * @param[in] mode - Boolean flag to control module state:
+ *                   - true: Enable dynamic contrast module
+ *                   - false: Disable dynamic contrast module
  *
  * @return tvError_t
  *


### PR DESCRIPTION
This pull request addresses Issue #111 by updating the documentation of the DynamicContrast APIs in tvSettings.h to improve clarity, consistency, and usability.

**Changes Made**

Renamed parameters for clarity and consistency:

dynamicContrastEnable → dynamicContrastMode
isDynamicContrastEnabled → dynamicContrastMode


Added explanatory notes to:

Clarify that SetDynamicContrast() and GetDynamicContrast() are independent of EnableDynamicContrast().
Explain that the dynamic contrast module is enabled by default in the PQ pipeline.
Highlight that EnableDynamicContrast() is intended for factory-side configuration and not required for runtime control.

Improved descriptions of valid values for parameters and return types.


**Affected APIs**

SetDynamicContrast(const char *dynamicContrastMode)
GetDynamicContrast(char *dynamicContrastMode)
EnableDynamicContrast(bool mode)


**Reason for change**
The previous documentation lacked clarity regarding the behavior and intended usage of the DynamicContrast APIs. This led to confusion during both integration and test suite development. These updates aim to provide developers with clearer guidance, reduce ambiguity, and ensure correct usage across development workflows.